### PR TITLE
Return correct content type

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ var acceptFormats = []responder{
 	},
 	responder{
 		accept:      "text/plain",
-		contentType: "application/vnd.google.protobuf;; pproto=io.prometheus.client.MetricFamily; encoding=delimited",
+		contentType: "text/plain; version=0.0.4; charset=utf-8",
 		converter:   prometheus.Converter,
 	},
 }


### PR DESCRIPTION
## What

As it turns out, prometheus has deprecated their custom content type and
will expect plain text in the future [1].

[1]: https://prometheus.io/docs/instrumenting/exposition_formats/

## How to review

- Make sure the change makes sense
- Optionally run the application and attempt to query it - see if the returned header is correct