### PR TITLE
[#160826728] Make server tests more blackbox

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,1 @@
+/paas-log-cache-adapter

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/paas-log-cache-adapter
+
 ### Go ###
 # Binaries for programs and plugins
 *.exe

--- a/server_test.go
+++ b/server_test.go
@@ -45,10 +45,10 @@ var _ = Describe("main package", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			srv.routes()
-			r, err := http.NewRequest("GET", "/", nil)
+			r, err := http.NewRequest("GET", "/metrics", nil)
 			Expect(err).NotTo(HaveOccurred())
 			w := httptest.NewRecorder()
-			srv.requireAuth(srv.chooseFormat(srv.handleMetrics()))(w, r)
+			srv.router.ServeHTTP(w, r)
 
 			Expect(w.Code).To(Equal(http.StatusUnauthorized))
 		})
@@ -58,13 +58,13 @@ var _ = Describe("main package", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			srv.routes()
-			r, err := http.NewRequest("GET", "/", nil)
+			r, err := http.NewRequest("GET", "/metrics", nil)
 			Expect(err).NotTo(HaveOccurred())
 			r.Header.Add("Authorization", "__JWT_ACCESS_TOKEN__")
 			r.Header.Add("Accept", "text/html")
 
 			w := httptest.NewRecorder()
-			srv.requireAuth(srv.chooseFormat(srv.handleMetrics()))(w, r)
+			srv.router.ServeHTTP(w, r)
 
 			Expect(w.Code).To(Equal(http.StatusNotAcceptable))
 		})
@@ -80,13 +80,13 @@ var _ = Describe("main package", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			srv.routes()
-			r, err := http.NewRequest("GET", "/", nil)
+			r, err := http.NewRequest("GET", "/metrics", nil)
 			Expect(err).NotTo(HaveOccurred())
 			r.Header.Add("Authorization", "__JWT_ACCESS_TOKEN__")
 			r.Header.Add("Accept", "text/plain")
 
 			w := httptest.NewRecorder()
-			srv.recordRequest(srv.requireAuth(srv.chooseFormat(srv.handleMetrics())))(w, r)
+			srv.router.ServeHTTP(w, r)
 
 			Expect(w.Code).To(Equal(http.StatusOK))
 			Expect(w.Header().Get("Content-Type")).To(Equal("text/plain"))
@@ -157,13 +157,13 @@ var _ = Describe("main package", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			srv.routes()
-			r, err := http.NewRequest("GET", "/", nil)
+			r, err := http.NewRequest("GET", "/metrics", nil)
 			Expect(err).NotTo(HaveOccurred())
 			r.Header.Add("Authorization", "__JWT_ACCESS_TOKEN__")
 			r.Header.Add("Accept", "text/plain")
 
 			w := httptest.NewRecorder()
-			srv.recordRequest(srv.requireAuth(srv.chooseFormat(srv.handleMetrics())))(w, r)
+			srv.router.ServeHTTP(w, r)
 
 			Expect(w.Code).To(Equal(http.StatusOK))
 			Expect(w.Header().Get("Content-Type")).To(Equal("text/plain"))


### PR DESCRIPTION
Some of our tests embed a reasonable level of implementation knowledge.
This change reduces that awareness a bit, by devolving the middleware chain
ordering to the server's `run` method that's actually used to serve the
app.

It's still slightly smelly, as it still requires the tests to be in the
same package as the implementation, so we can reach into the private
`server` struct and use its router. But that's not a /change/, so we end up
strictly better than before.

We also git+cf ignore the binary created when running tests.